### PR TITLE
Leverage githubs markdown renderer to fetch and syntax highlight readmes

### DIFF
--- a/public/css/vendor/github.css
+++ b/public/css/vendor/github.css
@@ -1,0 +1,122 @@
+/* syntax highlighting */
+
+ .highlight {
+  margin-bottom: 16px;
+}
+
+ .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+ .pl-c {
+  color: #969896;
+}
+
+ .pl-c1,
+ .pl-mdh,
+ .pl-mm,
+ .pl-mp,
+ .pl-mr,
+ .pl-s1 .pl-v,
+ .pl-s3,
+ .pl-sc,
+ .pl-sv {
+  color: #0086b3;
+}
+
+ .pl-e,
+ .pl-en {
+  color: #795da3;
+}
+
+ .pl-s1 .pl-s2,
+ .pl-smi,
+ .pl-smp,
+ .pl-stj,
+ .pl-vo,
+ .pl-vpf {
+  color: #333;
+}
+
+ .pl-ent {
+  color: #63a35c;
+}
+
+ .pl-k,
+ .pl-s,
+ .pl-st {
+  color: #a71d5d;
+}
+
+ .pl-pds,
+ .pl-s1,
+ .pl-s1 .pl-pse .pl-s2,
+ .pl-sr,
+ .pl-sr .pl-cce,
+ .pl-sr .pl-sra,
+ .pl-sr .pl-sre,
+ .pl-src,
+ .pl-v {
+  color: #df5000;
+}
+
+ .pl-id {
+  color: #b52a1d;
+}
+
+ .pl-ii {
+  background-color: #b52a1d;
+  color: #f8f8f8;
+}
+
+ .pl-sr .pl-cce {
+  color: #63a35c;
+  font-weight: bold;
+}
+
+ .pl-ml {
+  color: #693a17;
+}
+
+ .pl-mh,
+ .pl-mh .pl-en,
+ .pl-ms {
+  color: #1d3e81;
+  font-weight: bold;
+}
+
+ .pl-mq {
+  color: #008080;
+}
+
+ .pl-mi {
+  color: #333;
+  font-style: italic;
+}
+
+ .pl-mb {
+  color: #333;
+  font-weight: bold;
+}
+
+ .pl-md,
+ .pl-mdhf {
+  background-color: #ffecec;
+  color: #bd2c00;
+}
+
+ .pl-mdht,
+ .pl-mi1 {
+  background-color: #eaffea;
+  color: #55a532;
+}
+
+ .pl-mdr {
+  color: #795da3;
+  font-weight: bold;
+}
+
+ .pl-mo {
+  color: #1d3e81;
+}

--- a/resources/assets/js/store/actions.js
+++ b/resources/assets/js/store/actions.js
@@ -1,8 +1,6 @@
 import Vue from "vue";
 import VueResource from "vue-resource";
 import ls from "local-storage";
-import highlight from "highlight.js";
-import marked from "marked";
 import * as types from "./mutation-types.js";
 
 Vue.use(VueResource);
@@ -59,17 +57,17 @@ export const fetchGithubStars = ({ dispatch, state, actions }, page = 1) => {
 };
 
 export const fetchReadme = ({ dispatch }, name) => {
-  marked.setOptions({
-    sanitize: true,
-    breaks: true,
-    highlight: (code) => {
-      return highlight.highlightAuto(code).value;
-    }
-  });
   let accessToken = ls("access_token");
   Vue.http.get(`https://api.github.com/repos/${name}/readme?access_token=${accessToken}`).then( (response) => {
-    let readme = marked( window.atob(response.data.content) );
-    dispatch(types.SET_README, readme);
+    let readme  = atob(response.data.content);
+    Vue.http.post(`https://api.github.com/markdown/raw?access_token=${accessToken}`, readme, {
+      headers: {
+        "Content-Type": "text/plain"
+      }
+    }).then( (response) => {
+      let renderedReadme = response.data;
+      dispatch(types.SET_README, renderedReadme);
+    });
   });
 };
 

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -6,9 +6,9 @@
   <link rel="icon" type="image/png" href="/images/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="/images/favicon-16x16.png" sizes="16x16" />
   <link href='//fonts.googleapis.com/css?family=Karla:400,400italic,700,700italic' rel='stylesheet' type='text/css'>
-  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.8.0/styles/tomorrow.min.css">
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   {!! Html::style('css/vendor/select2.min.css') !!}
+  {!! Html::style('css/vendor/github.css') !!}
   <link rel="stylesheet" href="{{ elixir("css/app.css") }}">
 </head>
 <body>


### PR DESCRIPTION
To avoid some shortcomings with the markdown library I was using, this PR leverages Github's API to render readme markdown, which already includes special CSS classes for code highlighting. This way, we don't need to asynchronously highlight code, but rather just use an existing stylesheet. 