### PR TITLE
fix handle mutlibyte characters in readme.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dragula": "^3.6.3",
     "highlight.js": "^9.5.0",
     "jquery": "^2.2.0",
+    "js-base64": "^2.1.9",
     "local-storage": "^1.4.2",
     "lodash": "^4.0.0",
     "marked": "^0.3.5",

--- a/resources/assets/js/store/actions.js
+++ b/resources/assets/js/store/actions.js
@@ -2,6 +2,7 @@ import Vue from "vue"
 import VueResource from "vue-resource"
 import ls from "local-storage"
 import * as types from "./mutation-types.js"
+import { Base64 } from "js-base64"
 
 Vue.use(VueResource)
 
@@ -87,7 +88,7 @@ export const fetchReadme = ({ dispatch }, name) => {
   const accessToken = ls("access_token")
   const promise = new Promise((resolve, reject) => {
     Vue.http.get(`https://api.github.com/repos/${name}/readme?access_token=${accessToken}`).then((response) => {
-      const readme = decodeURIComponent(escape(window.atob(response.data.content)))
+      const readme = Base64.decode(response.data.content)
       Vue.http.post(`https://api.github.com/markdown/raw?access_token=${accessToken}`, readme, {
         headers: {
           "Content-Type": "text/plain"

--- a/resources/assets/js/store/actions.js
+++ b/resources/assets/js/store/actions.js
@@ -87,7 +87,7 @@ export const fetchReadme = ({ dispatch }, name) => {
   const accessToken = ls("access_token")
   const promise = new Promise((resolve, reject) => {
     Vue.http.get(`https://api.github.com/repos/${name}/readme?access_token=${accessToken}`).then((response) => {
-      const readme = window.atob(response.data.content)
+      const readme = decodeURIComponent(escape(window.atob(response.data.content)))
       Vue.http.post(`https://api.github.com/markdown/raw?access_token=${accessToken}`, readme, {
         headers: {
           "Content-Type": "text/plain"


### PR DESCRIPTION
window.atob cannot handle multibyte characters correctly.
![screen shot 2016-09-01 at 12 19 18 pm](https://cloud.githubusercontent.com/assets/1716558/18155373/d334fae2-703f-11e6-83ed-f7404fcf3ed3.png)
 
It can handle multibyte characters readme now.
![screen shot 2016-09-01 at 12 20 45 pm](https://cloud.githubusercontent.com/assets/1716558/18155418/2cd09ef8-7040-11e6-8f00-95beac6a15d8.png)

