### PR TITLE
Removed will-change on dropdown

### DIFF
--- a/resources/assets/sass/application/shared/modules/_dropdown.scss
+++ b/resources/assets/sass/application/shared/modules/_dropdown.scss
@@ -7,7 +7,6 @@
     margin: 0;
     opacity: 0;
     visibility: hidden;
-    will-change: transform, opacity;
     &.active {
       @include transform( translate(-50%, 2px) scale(1));
       opacity: 1;


### PR DESCRIPTION
A quick fix for blurry edit tags dropdown (#95).

> some changes of will-change result in the creation of a new compositor layer. The GPU however does not support subpixel antialiasing as done by the CPU in most browser, which will sometimes result in blurry content (especially with text).

[Everything You Need to Know About the CSS will-change Property](https://dev.opera.com/articles/css-will-change-property/)