### PR TITLE
Tag Slug Fix

### DIFF
--- a/app/Console/Commands/AddTagSlugs.php
+++ b/app/Console/Commands/AddTagSlugs.php
@@ -2,6 +2,7 @@
 
 namespace Astral\Console\Commands;
 
+use Astral\TagSlugger;
 use Illuminate\Console\Command;
 use Astral\Models\Tag;
 
@@ -39,7 +40,7 @@ class AddTagSlugs extends Command
         $tags = Tag::whereNull('slug')->orWhere('slug', '')->get();
         $bar = $this->output->createProgressBar(count($tags));
         foreach ($tags as $tag) {
-            $tag->slug = str_slug($tag->name);
+            $tag->slug = (new TagSlugger($tag->name))->fix();
             $tag->save();
             $bar->advance();
         }

--- a/app/Console/Commands/FixTagSlugs.php
+++ b/app/Console/Commands/FixTagSlugs.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Astral\Console\Commands;
+
+use Astral\Models\Tag;
+use Astral\TagSlugger;
+use Illuminate\Console\Command;
+
+class FixTagSlugs extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tags:fix';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fixes all tags to have the correct slug';
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $total_tags = Tag::count();
+
+        $bar = $this->output->createProgressBar($total_tags);
+
+        Tag::chunk(1000, function ($tags) use ($bar) {
+            foreach ($tags as $tag) {
+                $slug = (new TagSlugger($tag->name))->fix();
+                if ($tag->slug !== $slug) {
+                    $tag->slug = $slug;
+                    $tag->save();
+                }
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+
+        $this->info(PHP_EOL . "All slugs have been successfully fixed." . PHP_EOL);
+    }
+}

--- a/app/Console/Commands/FixTagSlugs.php
+++ b/app/Console/Commands/FixTagSlugs.php
@@ -54,6 +54,6 @@ class FixTagSlugs extends Command
 
         $bar->finish();
 
-        $this->info(PHP_EOL . "All slugs have been successfully fixed." . PHP_EOL);
+        $this->info(PHP_EOL.'All slugs have been successfully fixed.'.PHP_EOL);
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         Commands\ColorTags::class,
         Commands\AddTagSlugs::class,
+        Commands\FixTagSlugs::class,
     ];
 
     /**

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -2,6 +2,7 @@
 
 namespace Astral\Models;
 
+use Astral\TagSlugger;
 use Auth;
 use Illuminate\Database\Eloquent\Model;
 use JWTAuth;
@@ -84,11 +85,11 @@ class Tag extends Model
             JWTAuth::parseToken()->authenticate();
             $tag->user_id = Auth::id();
             $tag->sort_order = self::where('user_id', Auth::id())->count();
-            $tag->slug = str_slug($tag->name);
+            $tag->slug = (new TagSlugger($tag->name))->fix();
         });
 
         static::saving(function ($tag) {
-            $tag->slug = str_slug($tag->name);
+            $tag->slug = (new TagSlugger($tag->name))->fix();
         });
     }
 }

--- a/app/TagSlugger.php
+++ b/app/TagSlugger.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Astral;
+
+class TagSlugger
+{
+    protected $slug;
+
+    public function __construct($name)
+    {
+        $this->slug = strtolower($name);
+    }
+
+    private function replace_ampersand()
+    {
+        if(str_contains($this->slug, '&')) {
+            $this->slug = str_replace('&', ' and ', $this->slug);
+        }
+    }
+
+    private function replace_slash()
+    {
+        if(str_contains($this->slug, '/')) {
+            $this->slug = str_replace('/', ' ', $this->slug);
+        }
+    }
+
+    private function replace_hash()
+    {
+        if(str_contains($this->slug, '#')) {
+            $this->slug = str_replace('#', '', $this->slug);
+        }
+    }
+
+    private function replace_dotnet()
+    {
+        if($this->slug == '.net') {
+            $this->slug = 'dot-net';
+        } elseif (starts_with($this->slug, '.net ')) {
+            $this->slug = 'dot-net ';
+        } elseif (ends_with($this->slug, ' .net')) {
+            $this->slug = ' dot-net';
+        }
+    }
+
+    private function replace_quotes()
+    {
+        if (str_contains($this->slug, ['"',"'"])) {
+            $this->slug = str_replace(['"',"'"], ' ', $this->slug);
+        }
+    }
+
+    private function replace_cpp()
+    {
+        if(str_contains($this->slug, 'c++')) {
+            $this->slug = str_replace('c++', 'cpp', $this->slug);
+        }
+    }
+
+    private function replace_c_sharp()
+    {
+        if(str_contains($this->slug, 'c#')) {
+            $this->slug = str_replace('c#', 'c sharp', $this->slug);
+        }
+    }
+    private function replace_f_sharp()
+    {
+        if(str_contains($this->slug, 'f#')) {
+            $this->slug = str_replace('f#', 'f sharp', $this->slug);
+        }
+    }
+
+    private function replace_encoded_space()
+    {
+        if(str_contains($this->slug, '%20')) {
+            $this->slug = str_replace('%20', ' ', $this->slug);
+        }
+    }
+
+    private function replace_plus()
+    {
+        if(str_contains($this->slug, '+')) {
+            $this->slug = str_replace('+', ' ', $this->slug);
+        }
+    }
+
+    private function replace_dots()
+    {
+        if(str_contains($this->slug, '.')) {
+            $this->slug = str_replace('.', ' ', $this->slug);
+        }
+    }
+
+    public function fix()
+    {
+        $this->replace_ampersand();
+        $this->replace_slash();
+        $this->replace_quotes();
+        $this->replace_dotnet();
+        $this->replace_cpp();
+        $this->replace_c_sharp();
+        $this->replace_f_sharp();
+        $this->replace_hash();
+        $this->replace_plus();
+        $this->replace_dots();
+
+        if(str_slug($this->slug) !== '') {
+            return str_slug($this->slug);
+        }
+
+        $this->slug = urlencode($this->slug);
+        $this->replace_encoded_space();
+        $this->replace_plus();
+
+        return str_slug($this->slug) ?: str_random(6);
+    }
+}

--- a/app/TagSlugger.php
+++ b/app/TagSlugger.php
@@ -11,86 +11,6 @@ class TagSlugger
         $this->slug = strtolower($name);
     }
 
-    private function replace_ampersand()
-    {
-        if(str_contains($this->slug, '&')) {
-            $this->slug = str_replace('&', ' and ', $this->slug);
-        }
-    }
-
-    private function replace_slash()
-    {
-        if(str_contains($this->slug, '/')) {
-            $this->slug = str_replace('/', ' ', $this->slug);
-        }
-    }
-
-    private function replace_hash()
-    {
-        if(str_contains($this->slug, '#')) {
-            $this->slug = str_replace('#', '', $this->slug);
-        }
-    }
-
-    private function replace_dotnet()
-    {
-        if($this->slug == '.net') {
-            $this->slug = 'dot-net';
-        } elseif (starts_with($this->slug, '.net ')) {
-            $this->slug = 'dot-net ';
-        } elseif (ends_with($this->slug, ' .net')) {
-            $this->slug = ' dot-net';
-        }
-    }
-
-    private function replace_quotes()
-    {
-        if (str_contains($this->slug, ['"',"'"])) {
-            $this->slug = str_replace(['"',"'"], ' ', $this->slug);
-        }
-    }
-
-    private function replace_cpp()
-    {
-        if(str_contains($this->slug, 'c++')) {
-            $this->slug = str_replace('c++', 'cpp', $this->slug);
-        }
-    }
-
-    private function replace_c_sharp()
-    {
-        if(str_contains($this->slug, 'c#')) {
-            $this->slug = str_replace('c#', 'c sharp', $this->slug);
-        }
-    }
-    private function replace_f_sharp()
-    {
-        if(str_contains($this->slug, 'f#')) {
-            $this->slug = str_replace('f#', 'f sharp', $this->slug);
-        }
-    }
-
-    private function replace_encoded_space()
-    {
-        if(str_contains($this->slug, '%20')) {
-            $this->slug = str_replace('%20', ' ', $this->slug);
-        }
-    }
-
-    private function replace_plus()
-    {
-        if(str_contains($this->slug, '+')) {
-            $this->slug = str_replace('+', ' ', $this->slug);
-        }
-    }
-
-    private function replace_dots()
-    {
-        if(str_contains($this->slug, '.')) {
-            $this->slug = str_replace('.', ' ', $this->slug);
-        }
-    }
-
     public function fix()
     {
         $this->replace_ampersand();
@@ -104,7 +24,7 @@ class TagSlugger
         $this->replace_plus();
         $this->replace_dots();
 
-        if(str_slug($this->slug) !== '') {
+        if (str_slug($this->slug) !== '') {
             return str_slug($this->slug);
         }
 
@@ -113,5 +33,86 @@ class TagSlugger
         $this->replace_plus();
 
         return str_slug($this->slug) ?: str_random(6);
+    }
+
+    private function replace_ampersand()
+    {
+        if (str_contains($this->slug, '&')) {
+            $this->slug = str_replace('&', ' and ', $this->slug);
+        }
+    }
+
+    private function replace_slash()
+    {
+        if (str_contains($this->slug, '/')) {
+            $this->slug = str_replace('/', ' ', $this->slug);
+        }
+    }
+
+    private function replace_quotes()
+    {
+        if (str_contains($this->slug, ['"', "'"])) {
+            $this->slug = str_replace(['"', "'"], ' ', $this->slug);
+        }
+    }
+
+    private function replace_dotnet()
+    {
+        if ($this->slug == '.net') {
+            $this->slug = 'dot-net';
+        } elseif (starts_with($this->slug, '.net ')) {
+            $this->slug = 'dot-net ';
+        } elseif (ends_with($this->slug, ' .net')) {
+            $this->slug = ' dot-net';
+        }
+    }
+
+    private function replace_cpp()
+    {
+        if (str_contains($this->slug, 'c++')) {
+            $this->slug = str_replace('c++', 'cpp', $this->slug);
+        }
+    }
+
+    private function replace_c_sharp()
+    {
+        if (str_contains($this->slug, 'c#')) {
+            $this->slug = str_replace('c#', 'c sharp', $this->slug);
+        }
+    }
+
+    private function replace_f_sharp()
+    {
+        if (str_contains($this->slug, 'f#')) {
+            $this->slug = str_replace('f#', 'f sharp', $this->slug);
+        }
+    }
+
+    private function replace_hash()
+    {
+        if (str_contains($this->slug, '#')) {
+            $this->slug = str_replace('#', '', $this->slug);
+        }
+    }
+
+    private function replace_plus()
+    {
+        if (str_contains($this->slug, '+')) {
+            $this->slug = str_replace('+', ' ', $this->slug);
+        }
+    }
+
+    private function replace_dots()
+    {
+        if (str_contains($this->slug, '.')) {
+            $this->slug = str_replace('.', ' ', $this->slug);
+        }
+    }
+
+    private function replace_encoded_space()
+    {
+        if (str_contains($this->slug, '%20')) {
+            $this->slug = str_replace('%20', ' ', $this->slug);
+        }
     }
 }


### PR DESCRIPTION
Does some nice stuff like replace `c++` with `cpp`. Easy to add new `niceties` in the future, and rerun the replacement.