### PR TITLE
fixes installer not setting correct password in enviroment file.

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -166,5 +166,7 @@ class InstallCommand extends Command
         $question->setHidden(true)->setHiddenFallback($fallback);
 
         $password = $this->output->askQuestion($question);
+
+        return $password;
     }
 }


### PR DESCRIPTION
The environment file at the moment doesn't get the password populated on a local install due to the method not returning the value. This resolves this in the Install Command, 
